### PR TITLE
Change films_hash to films array

### DIFF
--- a/lib/api_communicator.rb
+++ b/lib/api_communicator.rb
@@ -22,7 +22,7 @@ def get_character_movies_from_api(character)
   #  of movies by title. play around with puts out other info about a given film.
 end
 
-def print_movies(films_hash)
+def print_movies(films_array)
   # some iteration magic and puts out the movies in a nice list
 end
 


### PR DESCRIPTION
Inconsistent argument naming in the lab. print_movies receives "films_array" when it's called, but in the pre-written function definition, it accepts the misnamed "films_hash" 